### PR TITLE
Add type alias `Map`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add type alias `Map` [#6]
+
 ## [0.3.0]
 
 ### Changed
@@ -22,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release
 
+[#6]: https://github.com/dusk-network/dusk-hamt/issues/6
 [Unreleased]: https://github.com/dusk-network/dusk-hamt/compare/v-0.3.0...HEAD
 [0.3.0]: https://github.com/dusk-network/dusk-hamt/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/dusk-hamt/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1]
+
 ### Added
 - Add type alias `Map` [#6]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-hamt"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 description = "HAMT datatructure for microkelvin"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ enum Bucket<K, V, A> {
 #[derive(Clone, Canon, Debug)]
 pub struct Hamt<K, V, A>([Bucket<K, V, A>; 4]);
 
+pub type Map<K, V> = Hamt<K, V, ()>;
+
 impl<K, V, A> Compound<A> for Hamt<K, V, A>
 where
     K: Canon,


### PR DESCRIPTION
Include a new type alias for pure map usage where we don't need to
customize the Microkelvin annotations.

Resolves #6