### PR TITLE
Add codecov to CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+
+github_checks: false

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -1,4 +1,4 @@
-on: [pull_request]
+on: [ pull_request ]
 
 name: Continuous integration
 
@@ -24,15 +24,37 @@ jobs:
     name: Nightly tests Debug Mode
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-      - uses: actions-rs/cargo@v1
+
+      - name: Install kcov
+        run: sudo apt install -y kcov
+
+      - name: Build test executables
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '-Cinline-threshold=0 -Clink-dead-code'
+          RUSTDOCFLAGS: '-Cinline-threshold=0 -Clink-dead-code'
         with:
           command: test
-          args: --all-features
+          args: --all-features --no-run
+
+      - name: Test with kcov
+        # Find every executable resulting from building the tests and run each
+        # one of them with kcov. This ensures all the code we cover is measured.
+        run: >
+          find target/debug/deps -type f -executable ! -name "*.*" -exec
+          kcov --exclude-pattern=/.cargo,/usr/lib,/target,/tests --verify target/cov {} \;
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
Adds code coverage generation to the CI and uploads it to [codecov](https://about.codecov.io).