### PR TITLE
Release 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Update `microkelvin` version to `0.10.0-rc`
+## [0.5.0] - 2021-01-14
+
+- Update `microkelvin` version to `0.10`
 - Change `persistance` by `persistence` for the feature name.
 
 ## [0.4.0] - 2021-07-02

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-hamt"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 description = "HAMT datatructure for microkelvin"
@@ -9,7 +9,7 @@ repository = "https://github.com/dusk-network/dusk-hamt"
 keywords = ["merkle", "datastructure", "hamt"]
 
 [dependencies]
-microkelvin = "0.10.0-rc"
+microkelvin = "0.10"
 canonical = "0.6"
 canonical_derive = "0.6"
 


### PR DESCRIPTION
- Bump to `0.5.0`
- Update CHANGELOG.md
- Update `microkelvin` version to `0.10`
- Change `persistance` by `persistence` for the feature name.