### PR TITLE
Hamt get and get_mut implementations fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dusk-hamt"
 version = "0.7.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
-edition = "2018"
+edition = "2021"
 description = "HAMT datatructure for microkelvin"
 license = "MPL-2.0"
 repository = "https://github.com/dusk-network/dusk-hamt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dusk-hamt"
 version = "0.7.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
-edition = "2021"
+edition = "2018"
 description = "HAMT datatructure for microkelvin"
 license = "MPL-2.0"
 repository = "https://github.com/dusk-network/dusk-hamt"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2022-02-10

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ where
     A::Archived: for<'any> CheckBytes<DefaultValidator<'any>>,
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
     <K as Archive>::Archived: Hash,
-    K: PartialEq,
+    K: Eq,
     K: Archive<Archived = K>,
 {
     fn get(
@@ -397,7 +397,7 @@ where
     A::Archived: for<'any> CheckBytes<DefaultValidator<'any>>,
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
     <K as Archive>::Archived: Hash,
-    K: PartialEq,
+    K: Eq,
     K: Archive<Archived = K>,
 {
     fn get(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,21 +336,9 @@ where
         &mut self,
         key: &K,
     ) -> Option<MappedBranchMut<Self, A, I, V>> {
-        let mut walk_result = self.walk_mut(PathWalker::new(hash(key)));
-        let filter_result = match &mut walk_result {
-            Some(b) =>
-                if hash(&b.leaf_mut().key) == hash(key) {
-                    Some(b)
-                } else {
-                    None
-                },
-            None => None,
-        };
-        if filter_result.is_none() {
-            None
-        } else {
-            walk_result.map(|branch| branch.map_leaf(|kv| kv.value_mut()))
-        }
+        self.walk_mut(PathWalker::new(hash(key)))
+            .and_then(|mut b| (hash(&b.leaf_mut().key) == hash(key)).then(|| b))
+            .and_then(|branch| Some(branch.map_leaf(|kv| kv.value_mut())))
     }
 }
 
@@ -372,24 +360,27 @@ where
     A: Annotation<KvPair<K, V>>,
     A::Archived: for<'any> CheckBytes<DefaultValidator<'any>>,
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
-    <K as Archive>::Archived: Hash
+    <K as Archive>::Archived: Hash,
 {
     fn get(
         &self,
         key: &K,
     ) -> Option<MappedBranch<Self, A, I, MaybeArchived<V>>> {
-        self.walk(PathWalker::new(hash(key))).
-            filter(|b|match b.leaf() {
+        self.walk(PathWalker::new(hash(key)))
+            .filter(|b| match b.leaf() {
                 MaybeArchived::Memory(kv) => hash(kv.key()) == hash(key),
                 MaybeArchived::Archived(kv) => hash(&kv.key) == hash(key),
-            }).map(|branch| {
-            branch.map_leaf::<MaybeArchived<V>>(|kv| match kv {
-                MaybeArchived::Memory(kv) => MaybeArchived::Memory(kv.value()),
-                MaybeArchived::Archived(kv) => {
-                    MaybeArchived::Archived(kv.value())
-                }
             })
-        })
+            .map(|branch| {
+                branch.map_leaf::<MaybeArchived<V>>(|kv| match kv {
+                    MaybeArchived::Memory(kv) => {
+                        MaybeArchived::Memory(kv.value())
+                    }
+                    MaybeArchived::Archived(kv) => {
+                        MaybeArchived::Archived(kv.value())
+                    }
+                })
+            })
     }
 }
 
@@ -403,23 +394,26 @@ where
     A: Annotation<KvPair<K, V>>,
     A::Archived: for<'any> CheckBytes<DefaultValidator<'any>>,
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
-    <K as Archive>::Archived: Hash
+    <K as Archive>::Archived: Hash,
 {
     fn get(
         &self,
         key: &K,
     ) -> Option<MappedBranch<Hamt<K, V, A, I>, A, I, MaybeArchived<V>>> {
-        self.walk(PathWalker::new(hash(key))).
-            filter(|b|match b.leaf() {
+        self.walk(PathWalker::new(hash(key)))
+            .filter(|b| match b.leaf() {
                 MaybeArchived::Memory(kv) => hash(kv.key()) == hash(key),
                 MaybeArchived::Archived(kv) => hash(&kv.key) == hash(key),
-            }).map(|branch| {
-            branch.map_leaf(|kv| match kv {
-                MaybeArchived::Memory(kv) => MaybeArchived::Memory(kv.value()),
-                MaybeArchived::Archived(kv) => {
-                    MaybeArchived::Archived(kv.value())
-                }
             })
-        })
+            .map(|branch| {
+                branch.map_leaf(|kv| match kv {
+                    MaybeArchived::Memory(kv) => {
+                        MaybeArchived::Memory(kv.value())
+                    }
+                    MaybeArchived::Archived(kv) => {
+                        MaybeArchived::Archived(kv.value())
+                    }
+                })
+            })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ where
         key: &K,
     ) -> Option<MappedBranchMut<Self, A, I, V>> {
         self.walk_mut(PathWalker::new(hash(key)))
-            .and_then(|mut b| (hash(&b.leaf_mut().key) == hash(key)).then(|| b))
+            .and_then(|mut b| (b.leaf_mut().key == *key).then(|| b))
             .and_then(|branch| Some(branch.map_leaf(|kv| kv.value_mut())))
     }
 }
@@ -361,6 +361,7 @@ where
     A::Archived: for<'any> CheckBytes<DefaultValidator<'any>>,
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
     <K as Archive>::Archived: Hash,
+    K: PartialEq,
 {
     fn get(
         &self,
@@ -368,7 +369,7 @@ where
     ) -> Option<MappedBranch<Self, A, I, MaybeArchived<V>>> {
         self.walk(PathWalker::new(hash(key)))
             .filter(|b| match b.leaf() {
-                MaybeArchived::Memory(kv) => hash(kv.key()) == hash(key),
+                MaybeArchived::Memory(kv) => *kv.key() == *key,
                 MaybeArchived::Archived(kv) => hash(&kv.key) == hash(key),
             })
             .map(|branch| {
@@ -395,6 +396,7 @@ where
     A::Archived: for<'any> CheckBytes<DefaultValidator<'any>>,
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
     <K as Archive>::Archived: Hash,
+    K: PartialEq,
 {
     fn get(
         &self,
@@ -402,7 +404,7 @@ where
     ) -> Option<MappedBranch<Hamt<K, V, A, I>, A, I, MaybeArchived<V>>> {
         self.walk(PathWalker::new(hash(key)))
             .filter(|b| match b.leaf() {
-                MaybeArchived::Memory(kv) => hash(kv.key()) == hash(key),
+                MaybeArchived::Memory(kv) => *kv.key() == *key,
                 MaybeArchived::Archived(kv) => hash(&kv.key) == hash(key),
             })
             .map(|branch| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,7 @@ where
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
     <K as Archive>::Archived: Hash,
     K: PartialEq,
+    K: Archive<Archived = K>,
 {
     fn get(
         &self,
@@ -370,7 +371,7 @@ where
         self.walk(PathWalker::new(hash(key)))
             .filter(|b| match b.leaf() {
                 MaybeArchived::Memory(kv) => *kv.key() == *key,
-                MaybeArchived::Archived(kv) => hash(&kv.key) == hash(key),
+                MaybeArchived::Archived(kv) => kv.key == *key,
             })
             .map(|branch| {
                 branch.map_leaf::<MaybeArchived<V>>(|kv| match kv {
@@ -397,6 +398,7 @@ where
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
     <K as Archive>::Archived: Hash,
     K: PartialEq,
+    K: Archive<Archived = K>,
 {
     fn get(
         &self,
@@ -405,7 +407,7 @@ where
         self.walk(PathWalker::new(hash(key)))
             .filter(|b| match b.leaf() {
                 MaybeArchived::Memory(kv) => *kv.key() == *key,
-                MaybeArchived::Archived(kv) => hash(&kv.key) == hash(key),
+                MaybeArchived::Archived(kv) => kv.key == *key,
             })
             .map(|branch| {
                 branch.map_leaf(|kv| match kv {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,6 @@ where
     A: Annotation<KvPair<K, V>>,
     A::Archived: for<'any> CheckBytes<DefaultValidator<'any>>,
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
-    <K as Archive>::Archived: Hash,
     K: Eq,
     K: Archive<Archived = K>,
 {
@@ -396,7 +395,6 @@ where
     A: Annotation<KvPair<K, V>>,
     A::Archived: for<'any> CheckBytes<DefaultValidator<'any>>,
     I: Archive + for<'any> CheckBytes<DefaultValidator<'any>>,
-    <K as Archive>::Archived: Hash,
     K: Eq,
     K: Archive<Archived = K>,
 {

--- a/tests/hamt.rs
+++ b/tests/hamt.rs
@@ -4,14 +4,14 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use bytecheck::CheckBytes;
 use dusk_hamt::{Hamt, Lookup};
 use microkelvin::{
     All, Annotation, Cardinality, Child, Compound, Keyed, MaybeArchived, Nth,
     OffsetLen,
 };
 use rkyv::rend::LittleEndian;
-use rkyv::{Archive, Serialize, Deserialize};
-use bytecheck::CheckBytes;
+use rkyv::{Archive, Deserialize, Serialize};
 
 fn correct_empty_state<C, A, I>(c: C) -> bool
 where
@@ -199,7 +199,7 @@ fn map_behavior_with_struct_key() {
     assert_eq!(TEST_SIZE % 256, 0);
 
     let mut secrets: Hamt<SecretHash, u32, (), OffsetLen> = Hamt::new();
-    for i in 0 .. TEST_SIZE {
+    for i in 0..TEST_SIZE {
         let secret_data: [u8; 32] = [(i % 256) as u8; 32];
         let secret_hash = SecretHash::new(secret_data);
         if let Some(mut branch) = secrets.get_mut(&secret_hash) {
@@ -209,26 +209,27 @@ fn map_behavior_with_struct_key() {
         }
     }
 
-    for i in 0 .. TEST_SIZE {
+    for i in 0..TEST_SIZE {
         let secret_data: [u8; 32] = [(i % 256) as u8; 32];
         let secret_hash = SecretHash::new(secret_data);
-        let value = secrets.get(&secret_hash)
+        let value = secrets
+            .get(&secret_hash)
             .as_ref()
             .map(|branch| match branch.leaf() {
                 MaybeArchived::Memory(m) => *m,
                 MaybeArchived::Archived(a) => (*a).into(),
             })
             .unwrap_or(0);
-        assert_eq!(value, TEST_SIZE/256);
+        assert_eq!(value, TEST_SIZE / 256);
     }
-
 }
 
 #[test]
 fn map_behavior_with_simple_key() {
-    let mut secrets: Hamt<LittleEndian<u64>, LittleEndian<u32>, (), OffsetLen> = Hamt::<LittleEndian<u64>, LittleEndian<u32>, (), OffsetLen>::new();
+    let mut secrets: Hamt<LittleEndian<u64>, LittleEndian<u32>, (), OffsetLen> =
+        Hamt::<LittleEndian<u64>, LittleEndian<u32>, (), OffsetLen>::new();
     const TEST_SIZE: u64 = 4 * 256;
-    for i in 0 .. TEST_SIZE {
+    for i in 0..TEST_SIZE {
         let key = i.into();
         if let Some(mut _branch) = secrets.get_mut(&key) {
             assert!(false);


### PR DESCRIPTION
Get and get_mut implementations were broken because of the omission of filters in their ports from the canonical version. 
This is now fixed plus relevant tests are added for it to prevent regression.