### PR TITLE
Microkelvin dependency change to 0.16.0-rkyv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `microkelvin` from `0.13.0-rc.0` to `0.16.0-rkyv.1`
+- Update `microkelvin` from `0.13.0-rc.0` to `0.16.0-rkyv`
 - Change `persistance` by `persistence` for the feature name.
 
 ## [0.4.0] - 2021-07-02

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-hamt"
-version = "0.11.0-rkyv.0"
+version = "0.11.0-rkyv.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 description = "HAMT datatructure for microkelvin"
@@ -10,9 +10,9 @@ keywords = ["merkle", "datastructure", "hamt"]
 
 [dependencies]
 bytecheck = { version = "0.6.7", default-features = false }
-microkelvin = { version = "0.16.0-rkyv.0", default-features = false }
+microkelvin = { version = "0.16.0-rkyv", default-features = false }
 rkyv = { version = "0.7.29", default-features = false, features = ["validation"] }
 seahash= { version = "4.1.0", default-features = false } 
 
 [dev-dependencies]
-microkelvin = "0.16.0-rkyv.1"
+microkelvin = "0.16.0-rkyv"


### PR DESCRIPTION
Microkelvin dependency change to 0.16.0-rkyv and version change to 0.11.0-rkyv.1